### PR TITLE
[feature/#54] Implement API for retrieving detailed information of ended auction products

### DIFF
--- a/src/main/java/com/api/jaebichuri/auction/dto/UpcomingAuctionProductDto.java
+++ b/src/main/java/com/api/jaebichuri/auction/dto/UpcomingAuctionProductDto.java
@@ -1,5 +1,6 @@
 package com.api.jaebichuri.auction.dto;
 
+import com.api.jaebichuri.auction.enums.AuctionCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,6 +21,9 @@ public class UpcomingAuctionProductDto {
 
     @Schema(description = "입찰 시작가", example = "10000")
     private String startPrice;
+
+    @Schema(description = "경매 카테고리", example = "CLOTHING")
+    private AuctionCategory auctionCategory;
 
     @Schema(description = "상품 이미지 URL", example = "https://example.com/image.jpg")
     private String imageUrl;

--- a/src/main/java/com/api/jaebichuri/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/api/jaebichuri/auction/repository/AuctionRepository.java
@@ -32,4 +32,6 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
     List<Auction> findByAuctionStatusAndEndTimeLessThanEqual(AuctionStatus auctionStatus, LocalDateTime time);
 
+    Optional<Auction> findByIdAndSeller(Long auctionId, Member member);
+
 }

--- a/src/main/java/com/api/jaebichuri/bid/service/AuctionBidService.java
+++ b/src/main/java/com/api/jaebichuri/bid/service/AuctionBidService.java
@@ -84,7 +84,7 @@ public class AuctionBidService {
         return handleNewAuctionBid(member, auction, requestBidPrice);
     }
 
-    private List<BidDatePriceResponse> getBidDatePriceResponseList(Auction auction) {
+    public List<BidDatePriceResponse> getBidDatePriceResponseList(Auction auction) {
         List<AuctionBid> top3ByAuctionBid = auctionBidRepository.findTop3ByAuctionOrderByBidPriceDesc(
             auction);
 
@@ -96,7 +96,7 @@ public class AuctionBidService {
         return top3BidDatePriceList;
     }
 
-    private List<BidVolumeResponse> getVolumeResponseList(Auction auction) {
+    public List<BidVolumeResponse> getVolumeResponseList(Auction auction) {
         List<AuctionBid> auctionBidList = auctionBidRepository.findAllByAuction(auction);
 
         Map<String, Long> volumeByDate = auctionBidList.stream()

--- a/src/main/java/com/api/jaebichuri/global/config/SecurityConfig.java
+++ b/src/main/java/com/api/jaebichuri/global/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/oauth2/kakao/**").permitAll()
                         .requestMatchers("/ws").permitAll()
-                        .requestMatchers("/auctions/**", "/products/**").permitAll()
+                        .requestMatchers("/auctions/**", "/products/upcoming/**").permitAll()
                         .requestMatchers(HttpMethod.PUT, "/admin/{screeningId}/status").hasAuthority("ADMIN")
                         .anyRequest().hasAnyAuthority("USER", "ADMIN")
                 );

--- a/src/main/java/com/api/jaebichuri/product/controller/ProductController.java
+++ b/src/main/java/com/api/jaebichuri/product/controller/ProductController.java
@@ -1,8 +1,11 @@
 package com.api.jaebichuri.product.controller;
 
+import com.api.jaebichuri.member.entity.Member;
+import com.api.jaebichuri.product.dto.EndedProductDetailsDto;
 import com.api.jaebichuri.product.dto.UpcomingProductDetailsDto;
 import com.api.jaebichuri.product.service.ProductService;
 import com.api.jaebichuri.global.response.ApiResponse;
+import com.api.jaebichuri.screening.dto.EndedAuctionProductDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -38,6 +42,26 @@ public class ProductController {
     @GetMapping("/upcoming/{auctionId}")
     public ResponseEntity<ApiResponse<UpcomingProductDetailsDto>> getUpcomingAuctionProductDetails(@PathVariable Long auctionId) {
         return ResponseEntity.ok(ApiResponse.onSuccess(productService.getUpcomingAuctionProductDetails(auctionId)));
+    }
+
+    @Operation(
+            summary = "마감된 경매 상품 상세 정보 조회 API",
+            description = "마감된 경매에 대한 상세 정보를 반환하는 API입니다.",
+            parameters = {
+                    @Parameter(name = "auctionId", description = "마감된 경매 식별자 ID", required = true)
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "COMMON200",
+                            description = "마감된 경매 물품 상세 정보 조회 결과",
+                            content = @Content(schema = @Schema(implementation = EndedAuctionProductDto.class))
+                    )
+            }
+    )
+    @GetMapping("/ended/{auctionId}")
+    public ResponseEntity<ApiResponse<EndedProductDetailsDto>> getEndedAuctionProductDetails(@PathVariable Long auctionId,
+                                                                                             @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(productService.getEndedAuctionDetails(auctionId, member)));
     }
 
 }

--- a/src/main/java/com/api/jaebichuri/product/dto/EndedProductDetailsDto.java
+++ b/src/main/java/com/api/jaebichuri/product/dto/EndedProductDetailsDto.java
@@ -1,0 +1,45 @@
+package com.api.jaebichuri.product.dto;
+
+import com.api.jaebichuri.bid.dto.AuctionBidHttpResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "마감된 경매 물품 상세 조회에 대한 정보 DTO")
+public class EndedProductDetailsDto {
+
+    @Schema(description = "경매 상품 식별자 ID", example = "1")
+    private Long productId;
+
+    @Schema(description = "상품명", example = "모자")
+    private String productName;
+
+    @Schema(description = "상품명", example = "모자에 대한 설명입니다.")
+    private String productDescription;
+
+    @Schema(description = "경매에 참여한 입찰자 수", example = "12")
+    private Long numOfBidders;
+
+    @Schema(description = "낙찰 여부 (true: 낙찰, false: 유찰)", example = "true")
+    private Boolean isBidSuccessful;
+
+    @Schema(description = "최종 낙찰가", example = "50000")
+    private Long finalBidPrice;
+
+    @Schema(description = "경매 등록자 닉네임", example = "에코마켓")
+    private String sellerNickname;
+
+    @Schema(description = "상품 사진 URL 목록")
+    private List<String> images;
+
+    @Schema(description = "입찰 날짜 및 가격 리스트")
+    private List<AuctionBidHttpResponse.BidDatePriceResponse> top3BidDatePrice;
+
+    @Schema(description = "날짜별 입찰 수량 리스트")
+    private List<AuctionBidHttpResponse.BidVolumeResponse> bidVolumeByDate;
+
+}

--- a/src/main/java/com/api/jaebichuri/product/entity/AuctionProduct.java
+++ b/src/main/java/com/api/jaebichuri/product/entity/AuctionProduct.java
@@ -29,6 +29,7 @@ public class AuctionProduct {
     private Auction auction;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "auction_product_id")
     private List<AuctionProductImage> images = new ArrayList<>();
 
     public List<AuctionProductImage> getImages() {

--- a/src/main/java/com/api/jaebichuri/product/mapper/ProductMapper.java
+++ b/src/main/java/com/api/jaebichuri/product/mapper/ProductMapper.java
@@ -1,5 +1,6 @@
 package com.api.jaebichuri.product.mapper;
 
+import com.api.jaebichuri.product.dto.EndedProductDetailsDto;
 import com.api.jaebichuri.product.dto.UpcomingProductDetailsDto;
 import com.api.jaebichuri.auction.entity.Auction;
 import com.api.jaebichuri.product.entity.AuctionProductImage;
@@ -21,6 +22,13 @@ public interface ProductMapper {
     @Mapping(source = "seller.nickname", target = "sellerNickname")
     @Mapping(target = "images", expression = "java(filterRepresentativeImages(auction.getProduct().getImages()))")
     UpcomingProductDetailsDto auctionToUpcomingAuctionProductDto(Auction auction);
+
+    @Mapping(source = "product.id", target = "productId")
+    @Mapping(source = "product.productName", target = "productName")
+    @Mapping(target = "productDescription", source = "product.productDescription")
+    @Mapping(source = "seller.nickname", target = "sellerNickname")
+    @Mapping(source = "product.images", target = "images")
+    EndedProductDetailsDto toEndedProductDetailsDto(Auction auction);
 
     default List<String> filterRepresentativeImages(List<AuctionProductImage> images) {
         return images.stream()

--- a/src/main/java/com/api/jaebichuri/product/service/ProductService.java
+++ b/src/main/java/com/api/jaebichuri/product/service/ProductService.java
@@ -32,12 +32,8 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public EndedProductDetailsDto getEndedAuctionDetails(Long auctionId, Member member) {
-        Auction auction = auctionRepository.findById(auctionId)
+        Auction auction = auctionRepository.findByIdAndSeller(auctionId, member)
                 .orElseThrow(() -> new CustomException(ErrorStatus._AUCTION_NOT_FOUND));
-
-        if (!auction.getSeller().equals(member)) {
-            throw new CustomException(ErrorStatus._ACCESS_DENIED);
-        }
 
         EndedProductDetailsDto endedProductDetailsDto = productMapper.toEndedProductDetailsDto(auction);
 

--- a/src/main/java/com/api/jaebichuri/product/service/ProductService.java
+++ b/src/main/java/com/api/jaebichuri/product/service/ProductService.java
@@ -1,5 +1,8 @@
 package com.api.jaebichuri.product.service;
 
+import com.api.jaebichuri.bid.service.AuctionBidService;
+import com.api.jaebichuri.member.entity.Member;
+import com.api.jaebichuri.product.dto.EndedProductDetailsDto;
 import com.api.jaebichuri.product.dto.UpcomingProductDetailsDto;
 import com.api.jaebichuri.auction.entity.Auction;
 import com.api.jaebichuri.auction.enums.AuctionStatus;
@@ -17,6 +20,7 @@ public class ProductService {
 
     private final AuctionRepository auctionRepository;
     private final ProductMapper productMapper;
+    private final AuctionBidService auctionBidService;
 
     @Transactional(readOnly = true)
     public UpcomingProductDetailsDto getUpcomingAuctionProductDetails(Long auctionId) {
@@ -24,6 +28,19 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(ErrorStatus._AUCTION_NOT_FOUND));
 
         return productMapper.auctionToUpcomingAuctionProductDto(auction);
+    }
+
+    @Transactional(readOnly = true)
+    public EndedProductDetailsDto getEndedAuctionDetails(Long auctionId, Member member) {
+        Auction auction = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new CustomException(ErrorStatus._AUCTION_NOT_FOUND));
+
+        EndedProductDetailsDto endedProductDetailsDto = productMapper.toEndedProductDetailsDto(auction);
+
+        endedProductDetailsDto.setTop3BidDatePrice(auctionBidService.getBidDatePriceResponseList(auction));
+        endedProductDetailsDto.setBidVolumeByDate(auctionBidService.getVolumeResponseList(auction));
+
+        return endedProductDetailsDto;
     }
 
 }

--- a/src/main/java/com/api/jaebichuri/product/service/ProductService.java
+++ b/src/main/java/com/api/jaebichuri/product/service/ProductService.java
@@ -35,6 +35,10 @@ public class ProductService {
         Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorStatus._AUCTION_NOT_FOUND));
 
+        if (!auction.getSeller().equals(member)) {
+            throw new CustomException(ErrorStatus._ACCESS_DENIED);
+        }
+
         EndedProductDetailsDto endedProductDetailsDto = productMapper.toEndedProductDetailsDto(auction);
 
         endedProductDetailsDto.setTop3BidDatePrice(auctionBidService.getBidDatePriceResponseList(auction));

--- a/src/main/java/com/api/jaebichuri/screening/entity/AuctionScreening.java
+++ b/src/main/java/com/api/jaebichuri/screening/entity/AuctionScreening.java
@@ -50,6 +50,7 @@ public class AuctionScreening extends BaseEntity {
     private Member seller;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "auction_screening_id")
     private List<AuctionScreeningImage> images = new ArrayList<>();
 
     public void updateSeller(Member seller) {


### PR DESCRIPTION
### PR Type
- [x]  Add feature
- [ ] Fix bug
- [x] Code refactoring
- [ ] Add or modify comments
- [ ]  Modify document
- [ ]  Change folder name or path 
- [ ] Delete code or file
- [ ] Changes that do not affect the code (e.g. correcting typos, rename variables, etc.)
- [ ] Update dependencies, environment variables, or build

### Changes
- 마감된 경매 상세 정보 조회 api 구현
- 진행 예정 경매 dto에 auctionCategory 필드 추가
- AuctionProduct, AuctionScreening 엔티티에 @JoinColumn 추가

### Notes
@JoinColumn이 추가되어도 문제가 생긴다면 다시 말씀해 주세요.
closed #54